### PR TITLE
Allow job control in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN ./configure --prefix /usr \
                 --enable-cap \
                 --enable-multibyte \
                 --with-term-lib='ncursesw tinfo' \
-                --without-tcsetpgrp
+                --with-tcsetpgrp
 RUN make
 RUN make -C Etc all FAQ FAQ.html
 RUN if test $ref = "master" ; then install_packages cm-super-minimal texlive-fonts-recommended texlive-latex-base texlive-latex-recommended ghostscript bsdmainutils ; fi


### PR DESCRIPTION
Without tcsetpgrp, JOB_CONTROL is undefined, which means that zsh is compiled without support for job control.

See:
- https://github.com/zsh-users/zsh/blob/c749a06bc9f15b5153d55b7f5e6f9a3a252e39f6/Src/zsh_system.h#L768-L771
- https://github.com/zsh-users/zsh/blob/c749a06bc9f15b5153d55b7f5e6f9a3a252e39f6/Src/options.c#L608
- https://github.com/zsh-users/zsh/blob/c749a06bc9f15b5153d55b7f5e6f9a3a252e39f6/Src/options.c#L802-L814

Fixes GitHub #14