### PR TITLE
Upgrade docker base images to debian stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb-extras:jessie-buildpack AS builder
+FROM bitnami/minideb-extras:stretch-buildpack AS builder
 ARG ref=master
 WORKDIR /tmp/zsh-build
 RUN install_packages autoconf \
@@ -31,7 +31,7 @@ RUN yes '' | adduser --shell /bin/sh --home /tmp/zsh-build --disabled-login --di
 RUN chown -R zshtest /tmp/zsh-build
 RUN su - zshtest -c 'make test' || true
 
-FROM bitnami/minideb:jessie
+FROM bitnami/minideb:stretch
 LABEL maintainer="https://github.com/zsh-users/zsh-docker"
 WORKDIR /
 COPY --from=builder /tmp/zsh-install /


### PR DESCRIPTION
Jessie is an obsolete stable version with package issues
https://www.debian.org/releases/

For example, trying to install python3 on the current `zshusers/zsh:5.1` (or any other version) fails to work.

```
apt-get update && apt-get install -y python3
...
Setting up python3.4 (3.4.2-1+deb8u3) ...
  File "/usr/lib/python3.4/http/client.py", line 1014
    raise InvalidURL(f"URL can't contain control characters. {url!r} "
                                                                     ^
SyntaxError: invalid syntax
...
dpkg: error processing package dh-python (--configure):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.19-18+deb8u10) ...
Errors were encountered while processing:
 python3.4
 python3
 dh-python
E: Sub-process /usr/bin/dpkg returned an error code (1)
```