### PR TITLE
Enable arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,8 +98,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          use: true
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -145,6 +151,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
           build-args: ref=${{ matrix.zsh-ref }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,6 @@ jobs:
 
     runs-on: 'ubuntu-latest'
 
-    timeout-minutes: 30
-
     permissions:
       packages: write
       contents: read
@@ -149,6 +147,7 @@ jobs:
 
       - name: Build and push image
         uses: docker/build-push-action@v2
+        timeout-minutes: 60
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,14 @@ COPY *.patch ./
 RUN for p in *.patch; do patch -s -p1 -r /dev/null -i $p || true; done
 
 RUN ./Util/preconfig
-RUN ./configure --prefix /usr \
+RUN build_platform=x86_64; \
+    case "$(dpkg --print-architecture)" in \
+      arm64) \
+        build_platform="aarch64" \
+        ;; \
+    esac; \
+    ./configure --build=${build_platform}-unknown-linux-gnu \
+                --prefix /usr \
                 --enable-pcre \
                 --enable-cap \
                 --enable-multibyte \


### PR DESCRIPTION
The base image, bitnami/minideb, supports both amd64 and arm64.

The Dockerfile had to be adjusted here so that ./configure gets
run with right build platform on arm64. It fails to do so automatically (on arm64).
